### PR TITLE
Add Faraday, Nokogiri, and ffi gems; fix LinkedIn badge include

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 # gem 'jekyll', '~> 4.3.3'
 gem 'bundler', '~> 2.5.15'
+gem 'faraday'
 gem 'faraday-retry'
 gem 'backports', '~> 3.25.0'
 gem 'kramdown'
@@ -9,6 +10,8 @@ gem 'puma'
 gem 'csv'
 gem 'base64'
 gem 'jekyll-paginate-v2'
+gem 'nokogiri'
+gem "ffi"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,9 @@ DEPENDENCIES
   base64
   bundler (~> 2.5.15)
   csv
+  faraday
   faraday-retry
+  ffi
   github-pages
   jekyll-feed (~> 0.17.0)
   jekyll-gist (~> 1.5.0)
@@ -315,6 +317,7 @@ DEPENDENCIES
   jekyll-sitemap (~> 1.4.0)
   jgd (~> 1.14.0)
   kramdown
+  nokogiri
   puma
   tzinfo (~> 2.0)
   tzinfo-data

--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -1,24 +1,20 @@
 ---
 layout: default
 ---
-</div>
+
 <div class="container">
-    <div class="row d-flex justify-content-center">
-        <div class="col-10 m10">
-            <div class="card">
-                <h1 class="card-title" style="text-align: center;"> Contact me! </h1>
-                {% include Github/github_follow_button.html %}
-                <p class="card-text" style="text-align: center;">
-                    If you have any questions, suggestions, or just want to say hello, feel free to reach out!
-                </p>
-                <!-- Include Github, Linkedin, and Email contact buttons -->
-                {%- include linkedin_badge.html -%}
-
-
-            </div>
-        </div>
+  <div class="row d-flex justify-content-center">
+    <div class="col-10 m10">
+      <div class="card">
+        <h1 class="card-title" style="text-align: center">Contact me!</h1>
+        {% include Github/github_follow_button.html %}
+        <p class="card-text" style="text-align: center">
+          If you have any questions, suggestions, or just want to say hello,
+          feel free to reach out!
+        </p>
+        <!-- Include Github, Linkedin, and Email contact buttons -->
+        {%- include Linkedin_badge.html -%}
+      </div>
     </div>
+  </div>
 </div>
-
-
-


### PR DESCRIPTION
Added 'faraday', 'nokogiri', and 'ffi' gems to Gemfile for enhanced HTTP and XML handling. Updated contact.html to use 'Linkedin_badge.html' for correct LinkedIn badge inclusion.