### PR TITLE
Fix images for projects and add new run config

### DIFF
--- a/.run/Image Processor.run.xml
+++ b/.run/Image Processor.run.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Jekyll Serve" type="ShConfigurationType">
-    <option name="SCRIPT_TEXT" value="watchexec -r -e md,html,scss,css,js,yml,png,jpg,jpeg,yaml,rb --ignore 'languages/**' --ignore 'assets/img/gallery/**' --ignore '_data/galleries/**' --ignore '_config_languages.yml' -- sh -c &quot;bundle exec jekyll clean &amp;&amp; ruby generate_language_pages.rb &amp;&amp; ruby generate_language_map.rb &amp;&amp; ruby gallery_generator.rb &amp;&amp; bundle exec jekyll build &amp;&amp; bundle exec jekyll serve&quot;" />
+  <configuration default="false" name="Image Processor" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="./image-processor.sh" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
-    <option name="SCRIPT_PATH" value="Jekyll Serve" />
+    <option name="SCRIPT_PATH" value="" />
     <option name="SCRIPT_OPTIONS" value="" />
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -11,7 +11,7 @@ layout: default
           <div class="card blog-post">
             <img
               class="card-img-top"
-              src="{{site.url}}{{site.baseurl}}{{ post.original }}"
+              src="{{site.url}}{{site.baseurl}}{{ post.thumbnail }}"
               alt="{{ post.title }}"
             />
             <div class="card-body center">


### PR DESCRIPTION
This pull request updates the project’s run configurations and makes a small fix to the blog layout. The most significant changes are the addition of a dedicated run configuration for the image processor script, a modification to the Jekyll serve workflow to skip image processing, and a correction to the blog post image display logic.

**Run configuration updates:**

* Added a new run configuration `.run/Image Processor.run.xml` to allow running the `image-processor.sh` script independently with `/bin/zsh` as the interpreter.
* Modified `.run/Jekyll Serve.run.xml` to remove the invocation of `image-processor.sh` from the Jekyll serve workflow, streamlining the build process.

**Blog layout fix:**

* Updated `_layouts/blog.html` to use `post.thumbnail` instead of `post.original` for the blog post image source, ensuring thumbnails are displayed correctly.